### PR TITLE
Added queue to worker

### DIFF
--- a/1/debian-9/rootfs/run.sh
+++ b/1/debian-9/rootfs/run.sh
@@ -6,8 +6,11 @@
 USER=airflow
 DAEMON=airflow
 EXEC=$(which $DAEMON)
-START_COMMAND="${EXEC} worker -q $AIRFLOW_QUEUE | tee /opt/bitnami/airflow/logs/airflow-worker.log"
-
+if [ $AIRFLOW_QUEUE ]; then
+    START_COMMAND="${EXEC} worker -q $AIRFLOW_QUEUE | tee /opt/bitnami/airflow/logs/airflow-worker.log"
+else
+    START_COMMAND="${EXEC} worker | tee /opt/bitnami/airflow/logs/airflow-worker.log"
+fi
 echo "Waiting for db..."
 counter=0;
 res=1000;

--- a/1/debian-9/rootfs/run.sh
+++ b/1/debian-9/rootfs/run.sh
@@ -6,7 +6,7 @@
 USER=airflow
 DAEMON=airflow
 EXEC=$(which $DAEMON)
-START_COMMAND="${EXEC} worker | tee /opt/bitnami/airflow/logs/airflow-worker.log"
+START_COMMAND="${EXEC} worker -q $AIRFLOW_QUEUE | tee /opt/bitnami/airflow/logs/airflow-worker.log"
 
 echo "Waiting for db..."
 counter=0;

--- a/1/debian-9/rootfs/run.sh
+++ b/1/debian-9/rootfs/run.sh
@@ -6,11 +6,7 @@
 USER=airflow
 DAEMON=airflow
 EXEC=$(which $DAEMON)
-if [ $AIRFLOW_QUEUE ]; then
-    START_COMMAND="${EXEC} worker -q $AIRFLOW_QUEUE | tee /opt/bitnami/airflow/logs/airflow-worker.log"
-else
-    START_COMMAND="${EXEC} worker | tee /opt/bitnami/airflow/logs/airflow-worker.log"
-fi
+START_COMMAND="${EXEC} worker ${AIRFLOW_QUEUE:+-q $AIRFLOW_QUEUE} | tee /opt/bitnami/airflow/logs/airflow-worker.log"
 echo "Waiting for db..."
 counter=0;
 res=1000;

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ If you want to run the application manually instead of using `docker-compose`, t
     -e AIRFLOW_DATABASE_NAME=bitnami_airflow \
     -e AIRFLOW_DATABASE_USERNAME=bn_airflow \
     -e AIRFLOW_DATABASE_PASSWORD=bitnami1 \
+    -e AIRFLOW_QUEUE=new_queue \
     --net airflow-tier \
     --volume airflow_worker_data:/bitnami \
     bitnami/airflow-worker:latest

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ The Airflow Worker instance can be customized by specifying environment variable
 - `AIRFLOW_WEBSERVER_HOST`: Airflow Worker webserver host. Default: **airflow**
 - `AIRFLOW_WEBSERVER_PORT_NUMBER`: Airflow Worker webserver port. Default: **8080**
 - `AIRFLOW_HOSTNAME_CALLABLE`: Method to obtain the hostname. No defaults.
+- `AIRFLOW_QUEUE`: A queue for the worker to pull tasks from.
 
 ##### Use an existing database
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

I added the possibility to spawn workers with a queue. 

**Benefits**

This allows workers to be directed to a specific workload, for instance different workers could have different libraries installed, having a queue specified will help direct tasks to the proper workers.

**Possible drawbacks**

If a user ends up using just this image and doesn't define the `AIRFLOW_QUEUE` environment variable, it will not launch. I use it in conjunction with the bitnami/airflow helm chart, and I've modified the chart there to specify a queue for the workers. see [here](https://github.com/bitnami/charts/pull/1703)

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
