### PR TITLE
moved requirements install out of nested if statement

### DIFF
--- a/1/debian-10/rootfs/app-entrypoint.sh
+++ b/1/debian-10/rootfs/app-entrypoint.sh
@@ -5,21 +5,21 @@
 
 print_welcome_page
 
+# Install custom python package if requirements.txt is present
+if [[ -f "/bitnami/python/requirements.txt" ]]; then
+    source /opt/bitnami/airflow/venv/bin/activate
+    pip install -r /bitnami/python/requirements.txt
+    deactivate
+fi
+
 if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/run.sh" ]]; then
     if [ ! $EUID -eq 0 ] && [ -e "$LIBNSS_WRAPPER_PATH" ]; then
     echo "airflow:x:$(id -u):$(id -g):Airflow:$AIRFLOW_HOME:/bin/false" > "$NSS_WRAPPER_PASSWD"
     echo "airflow:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 
     export LD_PRELOAD="$LIBNSS_WRAPPER_PATH"
+    fi
 
-fi
-
-    # Install custom python package if requirements.txt is present
-if [[ -f "/bitnami/python/requirements.txt" ]]; then
-    source /opt/bitnami/airflow/venv/bin/activate
-    pip install -r /bitnami/python/requirements.txt
-    deactivate
-fi
 
     nami_initialize airflow-worker
     info "Starting airflow-worker... "

--- a/2/debian-10/rootfs/app-entrypoint.sh
+++ b/2/debian-10/rootfs/app-entrypoint.sh
@@ -5,21 +5,21 @@
 
 print_welcome_page
 
+# Install custom python package if requirements.txt is present
+if [[ -f "/bitnami/python/requirements.txt" ]]; then
+    source /opt/bitnami/airflow/venv/bin/activate
+    pip install -r /bitnami/python/requirements.txt
+    deactivate
+fi
+
 if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/run.sh" ]]; then
     if [ ! $EUID -eq 0 ] && [ -e "$LIBNSS_WRAPPER_PATH" ]; then
     echo "airflow:x:$(id -u):$(id -g):Airflow:$AIRFLOW_HOME:/bin/false" > "$NSS_WRAPPER_PASSWD"
     echo "airflow:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 
     export LD_PRELOAD="$LIBNSS_WRAPPER_PATH"
+    fi
 
-fi
-
-    # Install custom python package if requirements.txt is present
-if [[ -f "/bitnami/python/requirements.txt" ]]; then
-    source /opt/bitnami/airflow/venv/bin/activate
-    pip install -r /bitnami/python/requirements.txt
-    deactivate
-fi
 
     nami_initialize airflow-worker
     info "Starting airflow-worker... "


### PR DESCRIPTION
**Description of the change**

Changes the `app-entrypoint.sh` script in both `/1` and `/2` to install requirements if they are present no matter what.  

I was running into issues with the Kubernetes Executor where custom requirements were not being installed on workers.  This fixes the issue.

**Benefits**

Requirements will be installed anytime the `app-entrypoint.sh` script is executed.

**Possible drawbacks**

No way to avoid requirement installation other than not adding requirements.

**Applicable issues**


**Additional information**

